### PR TITLE
Discovered an issue with the time, Heroku server is set to UTC so the…

### DIFF
--- a/db/notes.json
+++ b/db/notes.json
@@ -1,14 +1,14 @@
 [
     {
-        "note_id": "4315",
-        "date": "3.10.2021 @ 15:00:53",
-        "title": "Complete residential investment report",
-        "text": "✅   Complete draft report.\n  Distribute draft for comments.\n  Complete final version and issue for distribution. "
+        "note_id": "5e09",
+        "date": "(UTC)3.10.2021 @ 10:13:28",
+        "title": "Complete investor presentation",
+        "text": "Circulate draft for comment. \nAddress comments / update draft and complete for presenting to investors.\n\nsaved on:  (UTC)3.10.2021 @ 10:12:21"
     },
     {
-        "note_id": "40c1d",
-        "date": "3.10.2021 @ 15:10:53",
-        "title": "Complete investor presentation",
-        "text": "Draft investor presentation needs to be completed no later than Friday 19-Nov-21. "
+        "note_id": "de87",
+        "date": "(UTC)3.10.2021 @ 10:14:57",
+        "title": "Get present for assistant.",
+        "text": "Celebrating her 10 year service.  Bottle of champagne and flowers."
     }
 ]

--- a/routes/notes.js
+++ b/routes/notes.js
@@ -51,11 +51,11 @@ noted.post( "/", ( req, res ) => {
   // https://stackoverflow.com/questions/2998784/how-to-output-numbers-with-leading-zeros-in-javascript
   
   const today         = new Date(),
-        currentHour   = adjustedNumber(today.getHours(), 2),
-        currentMinute = adjustedNumber(today.getMinutes(), 2),
-        currentSecond = adjustedNumber(today.getSeconds(), 2);
+        currentHour   = adjustedNumber( today.getUTCHours(), 2 ),
+        currentMinute = adjustedNumber( today.getUTCMinutes(), 2 ),
+        currentSecond = adjustedNumber( today.getUTCSeconds(), 2 );
 
-  const timestamp = today.getDay() + "." + today.getMonth()+ "." + today.getFullYear()+ " @ " + 
+  const timestamp = "(UTC) " + today.getUTCDay() + "." + today.getUTCMonth()+ "." + today.getUTCFullYear()+ " @ " + 
                     currentHour + ":" + currentMinute + ":" + currentSecond;
 
   const { title, text } = req.body;


### PR DESCRIPTION
… app timestamp doesn't match with client side time.  I've adjusted the formula now to UTC and added UTC to the timestamp so it is clear.  Future improvement would be to allow users to put in their time difference to UTC.