### PR TITLE
Spotted a glitch with the notes.html page with page overflow when it is empty.

### DIFF
--- a/public/assets/css/styles.css
+++ b/public/assets/css/styles.css
@@ -5,6 +5,7 @@ body {
   height: 100%;
   margin: 0;
   padding: 0;
+  overflow-y: hidden;
 }
 
 .save-note {
@@ -14,6 +15,10 @@ body {
 .custom-bg{
   padding: 2rem 2rem;
   background-color: rgb(185, 175, 135);
+}
+
+.allow-overflow{
+  overflow-y: auto;
 }
 
 .icons i {

--- a/public/notes.html
+++ b/public/notes.html
@@ -30,7 +30,7 @@
       <div class="row">
         <div class="col-4 list-container">
           <div class="card">
-            <ul class="list-group"></ul>
+            <ul class="list-group allow-overflow"></ul>
           </div>
         </div>
         <div class="col-8">


### PR DESCRIPTION

This fix stops overflow on whole page and allows it for the saved notes area and text area only.